### PR TITLE
[Fix] plot type priority when generating new plot

### DIFF
--- a/src/main/java/com/alpsbte/plotsystem/core/system/plot/generator/DefaultPlotGenerator.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/plot/generator/DefaultPlotGenerator.java
@@ -92,8 +92,8 @@ public class DefaultPlotGenerator extends AbstractPlotGenerator {
     }
 
     @Override
-    protected void generateOutlines(@NotNull File plotSchematic, @Nullable File environmentSchematic) throws IOException, WorldEditException, SQLException {
-        super.generateOutlines(plotSchematic, environmentSchematic);
+    protected void generateOutlines(@NotNull File plotSchematic, @Nullable File environmentSchematic, PlotType type) throws IOException, WorldEditException, SQLException {
+        super.generateOutlines(plotSchematic, environmentSchematic, type);
 
         // If the player is playing in his own world, then additionally generate the plot in the city world
         if (PlotWorld.isOnePlotWorld(world.getWorldName()) && plotVersion >= 3 && plot.getStatus() != Status.completed) {

--- a/src/main/java/com/alpsbte/plotsystem/core/system/plot/generator/TutorialPlotGenerator.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/plot/generator/TutorialPlotGenerator.java
@@ -59,7 +59,7 @@ public class TutorialPlotGenerator extends AbstractPlotGenerator {
     }
 
     public void generateOutlines(int schematicId) throws SQLException, IOException, WorldEditException {
-        generateOutlines(((TutorialPlot) plot).getOutlinesSchematic(schematicId), null);
+        generateOutlines(((TutorialPlot) plot).getOutlinesSchematic(schematicId), null, plotType);
     }
 
     @Override

--- a/src/main/java/com/alpsbte/plotsystem/core/system/plot/world/OnePlotWorld.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/plot/world/OnePlotWorld.java
@@ -85,8 +85,8 @@ public class OnePlotWorld extends PlotWorld {
 
             new DefaultPlotGenerator(getPlot(), plotOwner, getPlot().getPlotType()) {
                 @Override
-                protected void generateOutlines(@NotNull File plotSchematic, @Nullable File environmentSchematic) throws SQLException, IOException, WorldEditException {
-                    super.generateOutlines(((Plot) getPlot()).getCompletedSchematic(), environmentSchematic);
+                protected void generateOutlines(@NotNull File plotSchematic, @Nullable File environmentSchematic, PlotType type) throws SQLException, IOException, WorldEditException {
+                    super.generateOutlines(((Plot) getPlot()).getCompletedSchematic(), environmentSchematic, type);
                 }
 
                 @Override

--- a/src/main/java/com/alpsbte/plotsystem/utils/conversion/CoordinateConversion.java
+++ b/src/main/java/com/alpsbte/plotsystem/utils/conversion/CoordinateConversion.java
@@ -58,6 +58,9 @@ public class CoordinateConversion {
      * @return the offset as double array {x,z}, {0,0} if not configured.
      */
     public static double[] getTerraOffset() {
+        // Plot-System does not exist, this class is initializing before its enabled.
+        if(PlotSystem.getPlugin() == null) return new double[]{0, 0};
+
         String configOffsetX = PlotSystem.getPlugin().getConfig().getString(ConfigPaths.TERRA_OFFSET_X, null);
         String configOffsetZ = PlotSystem.getPlugin().getConfig().getString(ConfigPaths.TERRA_OFFSET_Z, null);
 


### PR DESCRIPTION
* When first generating plot, plot type is default to Local Inspiration Mode and then set to a user configured type later after the plot finish generating.

 * This breaks because the plot shifting require accurate value before generating the plot, so the plot position is correct.

 * Fix is to expose PlotType field to all plot generator and use the user configured type for the parameter ensuring type accuracy.